### PR TITLE
Reduce Tomcat startup time

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -77,6 +77,8 @@ NOTE: We added a `VOLUME` pointing to "/tmp" because that is where a Spring Boot
 
 NOTE: You can use a `RUN` command to "touch" the jar file so that it has a file modification time (Docker creates all container files in an "unmodified" state by default). This actually isn't important for the simple app that we wrote, but any static content (e.g. "index.html") would require the file to have a modification time.
 
+NOTE: To reduce http://wiki.apache.org/tomcat/HowTo/FasterStartUp#Entropy_Source[Tomcat startup time] we added a system propery pointing to "/dev/urandom" as a source of entropy.
+
 To build the image, you can use some tooling for Maven or Gradle from the community (big thanks to https://github.com/Transmode/gradle-docker[Transmode] and https://github.com/spotify/docker-maven-plugin[Spotify] for making those tools available).
 
 === Build a Docker Image with Maven

--- a/README.adoc
+++ b/README.adoc
@@ -77,7 +77,7 @@ NOTE: We added a `VOLUME` pointing to "/tmp" because that is where a Spring Boot
 
 NOTE: You can use a `RUN` command to "touch" the jar file so that it has a file modification time (Docker creates all container files in an "unmodified" state by default). This actually isn't important for the simple app that we wrote, but any static content (e.g. "index.html") would require the file to have a modification time.
 
-NOTE: To reduce http://wiki.apache.org/tomcat/HowTo/FasterStartUp#Entropy_Source[Tomcat startup time] we added a system propery pointing to "/dev/urandom" as a source of entropy.
+NOTE: To reduce http://wiki.apache.org/tomcat/HowTo/FasterStartUp#Entropy_Source[Tomcat startup time] we added a system property pointing to "/dev/urandom" as a source of entropy.
 
 To build the image, you can use some tooling for Maven or Gradle from the community (big thanks to https://github.com/Transmode/gradle-docker[Transmode] and https://github.com/spotify/docker-maven-plugin[Spotify] for making those tools available).
 

--- a/complete/src/main/docker/Dockerfile
+++ b/complete/src/main/docker/Dockerfile
@@ -2,4 +2,4 @@ FROM java:7
 VOLUME /tmp
 ADD gs-spring-boot-docker-0.1.0.jar app.jar
 RUN bash -c 'touch /app.jar'
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]


### PR DESCRIPTION
Reduce Tomcat startup time by using a different source of entropy (/dev/urandom instead of /dev/random) as per http://wiki.apache.org/tomcat/HowTo/FasterStartUp#Entropy_Source. When using a long running VM such as boot2docker this issue appears rather quickly.