### PR TITLE
Upgraded Dockerfile to Java 8

### DIFF
--- a/complete/src/main/docker/Dockerfile
+++ b/complete/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7
+FROM java:8
 VOLUME /tmp
 ADD gs-spring-boot-docker-0.1.0.jar app.jar
 RUN bash -c 'touch /app.jar'


### PR DESCRIPTION
It seems like the [move](https://spring.io/blog/2015/06/17/spring-guides-move-to-java-8) of the guides to Java 8 made on omission of the Dockerfile in this guide.
This PR fixes the issue 