### PR TITLE
Passing Spring profiles to the Docker run command with environment variables

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -208,6 +208,19 @@ If you like you can also delete the container (it is persisted in your filesyste
 $ docker rm 81c723d22865
 ----
 
+=== Using Spring Profiles
+Running your freshly minted Docker image with Spring profiles is as easy as passing an environment variable to the Docker run command
+
+----
+$ docker run -e "SPRING_PROFILES_ACTIVE=prod" -p 8080:8080 -t springio/gs-spring-boot-docker
+----
+
+or
+
+----
+$ docker run -e "SPRING_PROFILES_ACTIVE=dev" -p 8080:8080 -t springio/gs-spring-boot-docker
+----
+
 == Summary
 
 Congratulations! You've just created a Docker container for a Spring Boot app! Spring Boot apps run on port 8080 inside the container by default and we mapped that to the same port on the host using "-p" on the command line.


### PR DESCRIPTION
I added instructions on passing the SPRING_PROFILES_ACTIVE environment variable to the Docker run command in order to run the app with a specific profile.