### PR TITLE
Changed base of Dockerfile

### DIFF
--- a/complete/src/main/docker/Dockerfile
+++ b/complete/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM frolvlad/alpine-oraclejdk8:slim
 VOLUME /tmp
 ADD gs-spring-boot-docker-0.1.0.jar app.jar
 RUN bash -c 'touch /app.jar'

--- a/complete/src/main/docker/Dockerfile
+++ b/complete/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM java:8-jre
 VOLUME /tmp
 ADD gs-spring-boot-docker-0.1.0.jar app.jar
 RUN bash -c 'touch /app.jar'


### PR DESCRIPTION
For the needs of the simple docker container that is created in this guide, it's probably best to use the official Java 8 Docker Image that only contains the JRE and not the full blown JDK.
This significantly reduces the size of the image with no loss of functionality with regards to the current guide