### PR TITLE
Update plugin docker-maven-plugin to 0.4.11

### DIFF
--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -32,7 +32,7 @@
             <plugin>
                 <groupId>com.spotify</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.4.9</version>
+                <version>0.4.11</version>
                 <configuration>
                     <imageName>${docker.image.prefix}/${project.artifactId}</imageName>
                     <dockerDirectory>src/main/docker</dockerDirectory>


### PR DESCRIPTION
This allows the project to build with a Docker for Mac setup.