### PR TITLE
[FIX]On a "docker stop" the Spring Boot application was not stopped g…

### DIFF
--- a/complete/Dockerfile
+++ b/complete/Dockerfile
@@ -2,4 +2,4 @@ FROM openjdk:8-jdk-alpine
 VOLUME /tmp
 ADD target/gs-spring-boot-docker-0.1.0.jar app.jar
 ENV JAVA_OPTS=""
-ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar /app.jar" ]
+ENTRYPOINT exec java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar /app.jar


### PR DESCRIPTION
On a "docker stop" the Spring Boot application was not stopped gracefully. Indeed the SIGTERM (on "docker stop") was sent to the "sh" process and not the "java" process. This delay considerably the stop of the container because it waits the grace period and terminate with a SIGKILL.
This is not an issue in a standalone Spring Boot application. But when running a Spring Boot application in Docker container in a Spring Cloud platform with Eureka (@EnableEurekaClient), when the docker container is stopped, it does not unregister from the discovery service server.

see : https://docs.docker.com/engine/reference/commandline/stop/

If accepted documentation should be adapted too : https://spring.io/guides/gs/client-side-load-balancing/