### PR TITLE
Fix `./gradlew build docker`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
-sudo: false
+sudo: required
 language: java
 jdk:
 - oraclejdk8
+services:
+- docker
 script:
 - test/run.sh
 notifications:

--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -32,9 +32,9 @@ bootJar {
 
 // tag::task[]
 docker {
-    name "${project.group}/${jar.baseName}"
-    files jar.archivePath
-    buildArgs(['JAR_FILE': "${jar.archiveName}"])
+    name "${project.group}/${bootJar.baseName}"
+    files bootJar.archivePath
+    buildArgs(['JAR_FILE': "${bootJar.archiveName}"])
 }
 // end::task[]
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -17,6 +17,13 @@ exit $ret
 fi
 rm -rf build
 
+./gradlew build docker
+ret=$?
+if [ $ret -ne 0 ]; then
+exit $ret
+fi
+rm -rf build
+
 cd ../initial
 
 mvn clean compile


### PR DESCRIPTION
This should be bootJar now. Plus adds tests so that it's easy to
detect when docker build is broken.

Fixes #45 

Obvious Fix