### PR TITLE
Add maven docker test

### DIFF
--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -35,13 +35,13 @@
                 <version>1.3.6</version>
                 <configuration>
                     <repository>${docker.image.prefix}/${project.artifactId}</repository>
-					<buildArgs>
-						<JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
-					</buildArgs>
+                    <buildArgs>
+                        <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
+                    </buildArgs>
                 </configuration>
             </plugin>
             <!-- end::plugin[] -->
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>

--- a/test/run.sh
+++ b/test/run.sh
@@ -3,7 +3,14 @@ cd $(dirname $0)
 
 cd ../complete
 
-mvn clean package
+./mvnw clean package
+ret=$?
+if [ $ret -ne 0 ]; then
+exit $ret
+fi
+rm -rf target
+
+./mvnw clean install dockerfile:build
 ret=$?
 if [ $ret -ne 0 ]; then
 exit $ret
@@ -19,7 +26,7 @@ rm -rf build
 
 cd ../initial
 
-mvn clean compile
+./mvnw clean compile
 ret=$?
 if [ $ret -ne 0 ]; then
 exit $ret


### PR DESCRIPTION
This PR adds a docker build test similar to PR #46 plus fixes the indentation in the pom.xml.

The build will likely fail without the docker-service for travis-ci but should work if this PR is rebased onto #46 

Obvious Fix