### PR TITLE
make docker task dependent on build task

### DIFF
--- a/complete/Dockerfile
+++ b/complete/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:8-jdk-alpine
 VOLUME /tmp
 ARG JAR_FILE
-ADD ${JAR_FILE} app.jar
+COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]

--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -32,6 +32,7 @@ bootJar {
 
 // tag::task[]
 docker {
+    dependsOn build
     name "${project.group}/${bootJar.baseName}"
     files bootJar.archivePath
     buildArgs(['JAR_FILE': "${bootJar.archiveName}"])


### PR DESCRIPTION
The `docker` task can not be executed directly, because this task doesn't generate a jar file.

Additionally I've replaced `ADD` with `COPY, what doesn't change the behavior but is in accordance with Docker best practices. 