### PR TITLE
support JAVA_OPTS  and docker stop SIGTERM

### DIFF
--- a/complete/Dockerfile
+++ b/complete/Dockerfile
@@ -2,4 +2,5 @@ FROM openjdk:8-jdk-alpine
 VOLUME /tmp
 ARG JAR_FILE
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+ENV JAVA_OPTS=""
+ENTRYPOINT exec java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar /app.jar


### PR DESCRIPTION
1.support JAVA_OPTS
    docker run -e "JAVA_OPTS=-Dserver.port=8080"
2.docker stop send SIGTERM signal