### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -77,7 +77,7 @@ This Dockerfile is very simple, but that's all you need to run a Spring Boot app
 
 NOTE: We added a `VOLUME` pointing to "/tmp" because that is where a Spring Boot application creates working directories for Tomcat by default. The effect is to create a temporary file on your host under "/var/lib/docker" and link it to the container under "/tmp". This step is optional for the simple app that we wrote here, but can be necessary for other Spring Boot applications if they need to actually write in the filesystem.
 
-NOTE: To reduce http://wiki.apache.org/tomcat/HowTo/FasterStartUp#Entropy_Source[Tomcat startup time] we added a system property pointing to "/dev/urandom" as a source of entropy. This is not necessary with more recent versions of Spring Boot, if you use the "standard" version of Tomcat (or any other web server).
+NOTE: To reduce https://wiki.apache.org/tomcat/HowTo/FasterStartUp#Entropy_Source[Tomcat startup time] we added a system property pointing to "/dev/urandom" as a source of entropy. This is not necessary with more recent versions of Spring Boot, if you use the "standard" version of Tomcat (or any other web server).
 
 To take advantage of the clean separation between dependencies and application resources in a Spring Boot fat jar file, we will use a slightly different implementation of the Dockerfile:
 
@@ -220,7 +220,7 @@ Docker client to the Docker daemon, please set:
 ----
 
 To see the app, you must visit the IP address in DOCKER_HOST instead of localhost. In this case,
-http://192.168.59.103:8080, the public facing IP of the VM.
+https://192.168.59.103:8080, the public facing IP of the VM.
 ====
 
 When it is running you can see in the list of containers, e.g:
@@ -258,7 +258,7 @@ $ docker run -e "SPRING_PROFILES_ACTIVE=dev" -p 8080:8080 -t springio/gs-spring-
 ----
 
 === Debugging the application in a Docker container
-To debug the application  http://docs.oracle.com/javase/8/docs/technotes/guides/jpda/conninv.html#Invocation[JPDA Transport] can be used. So we'll treat the container like a remote server.
+To debug the application  https://docs.oracle.com/javase/8/docs/technotes/guides/jpda/conninv.html#Invocation[JPDA Transport] can be used. So we'll treat the container like a remote server.
 To enable this feature pass a java agent settings in JAVA_OPTS variable and map agent's port
  to localhost during a container run. With the https://www.docker.com/products/docker#/mac[Docker for Mac] there is limitation due to that we can't
  access container by IP without https://github.com/docker/for-mac/issues/171[black magic usage].


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://192.168.59.103:8080 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://192.168.59.103:8080 ([https](https://192.168.59.103:8080) result ConnectTimeoutException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://docs.oracle.com/javase/8/docs/technotes/guides/jpda/conninv.html with 1 occurrences migrated to:  
  https://docs.oracle.com/javase/8/docs/technotes/guides/jpda/conninv.html ([https](https://docs.oracle.com/javase/8/docs/technotes/guides/jpda/conninv.html) result 200).
* [ ] http://wiki.apache.org/tomcat/HowTo/FasterStartUp with 1 occurrences migrated to:  
  https://wiki.apache.org/tomcat/HowTo/FasterStartUp ([https](https://wiki.apache.org/tomcat/HowTo/FasterStartUp) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 1 occurrences
* http://localhost:8080 with 2 occurrences