### PR TITLE
Add single quotes in dockerize gradle command

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -81,7 +81,7 @@ $ docker build -t springio/gs-spring-boot-docker .
 or (if you are using Gradle):
 
 ```
-$ docker build --build-arg JAR_FILE=build/libs/*.jar -t springio/gs-spring-boot-docker .
+$ docker build --build-arg 'JAR_FILE=build/libs/*.jar' -t springio/gs-spring-boot-docker .
 ```
 
 This command builds an image and tags it as `springio/gs-spring-boot-docker`.


### PR DESCRIPTION
Fixes #88

In my environment(Mac OS BigSur, Gradle, zsh).

This command not worked for me:

```shell
docker build --build-arg JAR_FILE=build/libs/*.jar -t springio/gs-spring-boot-docker .
```

And it worked for me:

```shell
docker build --build-arg 'JAR_FILE=build/libs/*.jar' -t springio/gs-spring-boot-docker .
```