### PR TITLE
ISSUE-90 // zsh: no matches found: JAR_FILE=build/libs/*.jar #90

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -86,7 +86,7 @@ If you use Gradle, you can run it with the following command:
 ====
 [source,bash,subs="attributes"]
 ----
-docker build --build-arg JAR_FILE=build/libs/*.jar -t springio/gs-spring-boot-docker .
+docker build --build-arg JAR_FILE=build/libs/\*.jar -t springio/gs-spring-boot-docker .
 ----
 ====
 


### PR DESCRIPTION
1. Use escape character in docker build command for gradle
2. update README.adoc