### PR TITLE
Fix version consistency

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -84,7 +84,7 @@ Docker has a simple https://docs.docker.com/reference/builder/["Dockerfile"] fil
 ====
 [source]
 ----
-FROM openjdk:8-jdk-alpine
+FROM eclipse-temurin:8-jdk-alpine
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java","-jar","/app.jar"]
@@ -122,7 +122,7 @@ So, an important improvement to the `Dockerfile` is to run the application as a 
 ====
 [source]
 ----
-FROM openjdk:8-jdk-alpine
+FROM eclipse-temurin:8-jdk-alpine
 RUN addgroup -S spring && adduser -S spring -G spring
 USER spring:spring
 ARG JAR_FILE=target/*.jar

--- a/README.adoc
+++ b/README.adoc
@@ -13,7 +13,7 @@ NOTE: There is also a https://spring.io/guides/topicals/spring-boot-docker[Topic
 https://docker.com[Docker] is a Linux container management toolkit with a "`social`" aspect, letting users publish container images and consume those published by others. A Docker image is a recipe for running a containerized process. In this guide, we build one for a simple Spring boot application.
 
 == What You Will Need
-:java_version: 1.8
+:java_version: 17
 include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/main/prereq_editor_jdk_buildtools.adoc[]
 
 If you are NOT using a Linux machine, you need a virtualized server. If you install VirtualBox, other tools like the Mac's `boot2docker` can seamlessly manage it for you. Visit https://www.virtualbox.org/wiki/Downloads[VirtualBox's download site] and pick the version for your machine. Download and install. Do not worry about actually running it.
@@ -23,7 +23,7 @@ You also need https://docker.com[Docker], which only runs on 64-bit machines. Se
 [[scratch]]
 == Starting with Spring Initializr
 
-You can use this https://start.spring.io/#!type=maven-project&language=java&platformVersion=2.5.5&packaging=jar&jvmVersion=11&groupId=com.example&artifactId=spring-boot-docker&name=spring-boot-docker&description=Demo%20project%20for%20Spring%20Boot&packageName=com.example.spring-boot-docker&dependencies=web[pre-initialized project] and click Generate to download a ZIP file. This project is configured to fit the examples in this tutorial.
+You can use this https://start.spring.io/#!type=maven-project&language=java&platformVersion=3.0.0&packaging=jar&jvmVersion=17&groupId=com.example&artifactId=spring-boot-docker&name=spring-boot-docker&description=Demo%20project%20for%20Spring%20Boot&packageName=com.example.spring-boot-docker&dependencies=web[pre-initialized project] and click Generate to download a ZIP file. This project is configured to fit the examples in this tutorial.
 
 To manually initialize the project:
 
@@ -84,7 +84,7 @@ Docker has a simple https://docs.docker.com/reference/builder/["Dockerfile"] fil
 ====
 [source]
 ----
-FROM eclipse-temurin:8-jdk-alpine
+FROM eclipse-temurin:17-jdk-alpine
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java","-jar","/app.jar"]
@@ -122,7 +122,7 @@ So, an important improvement to the `Dockerfile` is to run the application as a 
 ====
 [source]
 ----
-FROM eclipse-temurin:8-jdk-alpine
+FROM eclipse-temurin:17-jdk-alpine
 RUN addgroup -S spring && adduser -S spring -G spring
 USER spring:spring
 ARG JAR_FILE=target/*.jar

--- a/complete/Dockerfile
+++ b/complete/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:8-jdk-alpine
+FROM eclipse-temurin:17-jdk-alpine
 RUN addgroup -S spring && adduser -S spring -G spring
 USER spring:spring
 ARG DEPENDENCY=target/dependency

--- a/complete/Dockerfile
+++ b/complete/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM eclipse-temurin:8-jdk-alpine
 RUN addgroup -S spring && adduser -S spring -G spring
 USER spring:spring
 ARG DEPENDENCY=target/dependency


### PR DESCRIPTION
Address the issue #104 where guide is using 1.8 in some locations whereas the minimum version for spring boot 3.x is 17.

Also shifted the base docker image to use eclipse-temurin as openjdk image has officially been deprecated.

https://github.com/docker-library/openjdk/issues/505