### PR TITLE
Update Docker jdk version

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -83,7 +83,7 @@ Docker has a simple https://docs.docker.com/reference/builder/["Dockerfile"] fil
 ====
 [source]
 ----
-FROM openjdk:8-jdk-alpine
+FROM eclipse-temurin:24-jdk-alpine
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java","-jar","/app.jar"]
@@ -121,7 +121,7 @@ So, an important improvement to the `Dockerfile` is to run the application as a 
 ====
 [source]
 ----
-FROM openjdk:8-jdk-alpine
+FROM eclipse-temurin:24-jdk-alpine
 RUN addgroup -S spring && adduser -S spring -G spring
 USER spring:spring
 ARG JAR_FILE=target/*.jar

--- a/complete/Dockerfile
+++ b/complete/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM eclipse-temurin:24-jdk-alpine
 RUN addgroup -S spring && adduser -S spring -G spring
 USER spring:spring
 ARG DEPENDENCY=target/dependency


### PR DESCRIPTION
Resolves unsupported class version error.
```
Exception in thread "main" java.lang.UnsupportedClassVersionError: com/example/spring_boot_docker/SpringBootDockerApplication has been compiled by a more recent version of the Java Runtime (class file version ...),
 this version of the Java Runtime only recognizes class file versions up to ...
```